### PR TITLE
Fix broken dependencies

### DIFF
--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -25,7 +25,7 @@ class superset::python inherits superset {
 
   $deps = [
     'apache-superset', 'eventlet', 'fbprophet', 'gevent', 'greenlet', 'gsheetsdb',
-    'gunicorn', 'psycopg2', 'pyldap', 'sqlalchemy'
+    'gunicorn', 'psycopg2', 'pyldap', 'pystan<3.0', 'sqlalchemy'
   ]
 
   python::pip { 'pystan':

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -24,8 +24,8 @@ class superset::python inherits superset {
   }
 
   $deps = [
-    'apache-superset', 'eventlet', 'fbprophet', 'gevent', 'greenlet', 'gsheetsdb',
-    'gunicorn', 'psycopg2', 'pyldap', 'pystan<3.0', 'sqlalchemy'
+    'apache-superset[prophet, postgres]', 'eventlet', 'gevent', 'greenlet', 'gsheetsdb',
+    'gunicorn', 'pyldap', 'pystan<3.0', 'sqlalchemy'
   ]
 
   python::pip { 'pystan':


### PR DESCRIPTION
Pystan has released a major version (3.x) that include breaking changes, incompatible with `(fb)prophet`.

So we here specify compatible `pystan` versions. We also read dependencies from `apache-superset` options, rather than explicitly specifying them in the manifest.