### PR TITLE
Parametrize which Superset version to install

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,3 +18,4 @@ superset::concurrency: 4
 superset::manage_database: true
 superset::ldap_enabled: false
 superset::row_limit: None
+superset::version: present

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,4 +18,4 @@ superset::concurrency: 4
 superset::manage_database: true
 superset::ldap_enabled: false
 superset::row_limit: None
-superset::version: present
+superset::version: latest

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class superset (
   String $log_level,
   Integer $concurrency,
   Variant[Integer, Enum['None']] $row_limit,
+  Variant[Enum[present, absent, latest], String[1]] $version,
   Boolean $ldap_enabled,
   Boolean $manage_database,
   Hash[String, Array[String]] $ldap_roles_mapping,

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -44,7 +44,7 @@ class superset::python inherits superset {
   }
 
   python::pip { 'apache-superset[prophet, postgres]':
-    ensure       => "$version",
+    ensure       => $version,
     virtualenv   => "${base_dir}/venv",
     pip_provider => 'pip3',
     owner        => $owner,

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -57,6 +57,6 @@ class superset::python inherits superset {
     onlyif  => "test `ls -aZ ${base_dir}/venv/bin/gunicorn | grep -c bin_t` -eq 0",
     user    => 'root',
     path    => '/sbin:/usr/sbin:/bin:/usr/bin',
-    require => [Python::Pip['pystan'], Python::Pip[$deps], Python::Pip['apache-superset']]
+    require => [Python::Pip['apache-superset']]
   }
 }

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -43,8 +43,9 @@ class superset::python inherits superset {
     require      => Python::Pip['pystan']
   }
 
-  python::pip { 'apache-superset[prophet, postgres]':
+  python::pip { 'apache-superset':
     ensure       => $version,
+    extras       => ['prophet', 'postgres'],
     virtualenv   => "${base_dir}/venv",
     pip_provider => 'pip3',
     owner        => $owner,
@@ -56,6 +57,6 @@ class superset::python inherits superset {
     onlyif  => "test `ls -aZ ${base_dir}/venv/bin/gunicorn | grep -c bin_t` -eq 0",
     user    => 'root',
     path    => '/sbin:/usr/sbin:/bin:/usr/bin',
-    require => [Python::Pip[$deps], Python::Pip['apache-superset[prophet, postgres]']]
+    require => [Python::Pip['pystan'], Python::Pip[$deps], Python::Pip['apache-superset']]
   }
 }


### PR DESCRIPTION
We want to be able to define which Superset version to install as an
instance parameter.

As default, we have used 'present' — which is a hacky was to not specify
which one, and so default to the latest.

Signed-off-by: Étienne Boisseau-Sierra <etienne.boisseau-sierra@unipart.io>