### PR TITLE
Enable adding devs SSH keys to instance

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,3 +18,4 @@ superset::concurrency: 4
 superset::manage_database: true
 superset::ldap_enabled: false
 superset::row_limit: None
+superset::ssh_key_devs: {}

--- a/manifests/sshkeys.pp
+++ b/manifests/sshkeys.pp
@@ -1,0 +1,17 @@
+# =Class superset::ssh
+class superset::ssh inherits superset {
+  $ssh_key_devs = lookup('ssh_key_devs', Hash[String, String], 'hash')
+
+  file { "/home/${owner}/.ssh/authorized_keys":
+    ensure  => present,
+    require => File["/home/${owner}/.ssh/"],
+  }
+
+  $ssh_key_devs.each |$comment, $key| {
+    ssh_authorized_key { $comment:
+      ensure => present,
+      type   => 'ssh-rsa',
+      key    => $key
+    }
+  }
+}


### PR DESCRIPTION
We want to be able to add devs' (i.e. non SysAdmins) SSH keys to the
instance.

They should then be specified as an instance parameter, as a hash
'comment' ￫ 'pubkey'.

Signed-off-by: Étienne Boisseau-Sierra <etienne.boisseau-sierra@unipart.io>