### PR TITLE
Add missing parameters to config file

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,6 @@
 ---
+superset::admin_email: ''
+superset::admin_pass: ''
 superset::admin_user: admin
 superset::base_dir: /opt/superset
 superset::owner: fedora


### PR DESCRIPTION
The manifest requires an admin email and password to be passed as
parameters (cf.
https://github.com/unipartdigital/puppet-superset/blob/ecd956cd08b76510dfe80933dd65e8cbb1488b23/manifests/init.pp#L3-L5
).

However, these aren't listed in the default config file
(https://github.com/unipartdigital/puppet-superset/blob/ecd956cd08b76510dfe80933dd65e8cbb1488b23/data/common.yaml)

That's what we've fixed!

Signed-off-by: Étienne Boisseau-Sierra <etienne.boisseau-sierra@unipart.io>