### PR TITLE
change default logo path

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,7 +7,7 @@ superset::db_host: localhost
 superset::db_name: superset
 superset::db_user: superset
 superset::version: present
-superset::logo_path: ''
+superset::logo_path:
 superset::ldap_server: ''
 superset::ldap_bind_user: ''
 superset::ldap_bind_pass: ''


### PR DESCRIPTION
When the logo path is empty string as is the default now, the block in  https://github.com/unipartdigital/puppet-superset/blob/873ef2e91196ba9672a3219e77a07f97b8bd887f/manifests/install.pp#L57-L64 gets executed nonetheless because empty strings are still truthy in Puppet and fails with:
`Error: Parameter source failed on File[/opt/superset/venv/lib/python3.8/site-packages/superset/static/assets/images/logo.png]: Cannot use relative URLs ''`

Even though we default it to undef here:
https://github.com/unipartdigital/puppet-superset/blob/2671f172e326461102551f6a3c2cadbe4cea3d7b/manifests/init.pp#L27

I think it gets overwritten with the empty string from hiera.

I suggest leaving the value empty. I tried setting it to `undef` as well but it just gets converted to string.