### PR TITLE
parametrize python version

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,5 @@
 ---
+superset::python_version: '3.7'
 superset::admin_user: admin
 superset::base_dir: /opt/superset
 superset::owner: fedora

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # =Class superset
 class superset (
+  String $python_version,
   String $admin_email,
   String $admin_user,
   String $admin_pass,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -55,7 +55,7 @@ class superset::install inherits superset {
   }
 
   if ($logo_path) {
-    file { "${base_dir}/venv/lib/python3.8/site-packages/superset/static/assets/images/logo.png":
+    file { "${base_dir}/venv/lib/python${python_version}/site-packages/superset/static/assets/images/logo.png":
       ensure => present,
       source => $logo_path,
       owner  => $owner,

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -3,8 +3,13 @@ class superset::python inherits superset {
   require superset::selinux
   require superset::package
 
+  package { "python${python_version}":
+    ensure => present,
+  }
+
   class { 'python':
-    pip  => present,
+    version => $python_version,
+    pip => present,
     dev  => present,
   }
 
@@ -17,7 +22,7 @@ class superset::python inherits superset {
   python::pyvenv { "${base_dir}/venv":
     ensure   => present,
     venv_dir => "${base_dir}/venv",
-    version  => 'system',
+    version  => $python_version,
     owner    => $owner,
     group    => $group,
     require  => [Class['python'], File[$base_dir]],


### PR DESCRIPTION
There was a recent bug in Python standard library (https://bugs.python.org/issue44061) which breaks Superset. The bug is in Python versions 3.8.10 and 3.9.5. When this manifest is run, it uses the latest version of the default installation of Python, which on many Linux distros currently ends up being exactly the bug-containing Python 3.8.10.

For this and many other reasons, it would be beneficial to allow the user to select which Python version to use.

I have tested these changes with Python 3.7 and 3.8. 