### PR TITLE
Fix thumbnails

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -2,11 +2,22 @@
 class superset::package inherits superset {
   $deps = [
     'gcc', 'gcc-c++', 'libffi-devel', 'chromedriver', 'git',
+    'dnf-plugins-core', 'fedora-workstation-repositories',
     'openssl-devel', 'cyrus-sasl-devel', 'openldap-devel'
   ]
 
   package { $deps:
     ensure => present
+  }
+
+  exec { 'enable chrome':
+    command     => "/usr/bin/dnf config-manager --set-enabled google-chrome",
+    require     => Package[$deps]
+  }
+
+  package { 'google-chrome-stable':
+    ensure  => present,
+    require => Exec['enable chrome']
   }
 
   file { '/etc/conf.d':

--- a/templates/opt/superset/superset_config.py.erb
+++ b/templates/opt/superset/superset_config.py.erb
@@ -61,7 +61,7 @@ class CeleryConfig(object):
 CELERY_CONFIG = CeleryConfig
 
 WEBDRIVER_TYPE = "chrome"
-WEBDRIVER_BASEURL = "https://$(hostname).$(dnsdomainname)"
+WEBDRIVER_BASEURL = "http://localhost:8080"
 WEBDRIVER_OPTION_ARGS = [
     "--force-device-scale-factor=2.0",
     "--high-dpi-support=2.0",

--- a/templates/opt/superset/superset_config.py.erb
+++ b/templates/opt/superset/superset_config.py.erb
@@ -44,7 +44,7 @@ THUMBNAIL_CACHE_CONFIG = {
     'CACHE_NO_NULL_WARNING': True,
     'CACHE_REDIS_URL': 'redis://localhost:6379/0'
 }
-
+THUMBNAIL_SELENIUM_USER = "@admin_user"
 
 class CeleryConfig(object):
     BROKER_URL = 'redis://localhost:6379/0'


### PR DESCRIPTION
This PR fixes thumbnails of charts and dashboards not being generated and cached. The reasons are:

1. missing Google Chrome which is needed for the webdriver to work
2. bash substitution done in `.erb` file which does not use bash