### PR TITLE
Fix thumbnails pt 2 / Add chromium

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,12 +1,18 @@
 # =Class superset::package
 class superset::package inherits superset {
   $deps = [
-    'gcc', 'gcc-c++', 'libffi-devel', 'chromedriver', 'git',
+    'gcc', 'gcc-c++', 'libffi-devel', 'chromium', 'chromedriver', 'git',
     'openssl-devel', 'cyrus-sasl-devel', 'openldap-devel'
   ]
 
   package { $deps:
     ensure => present
+  }
+
+  file { '/usr/bin/google-chrome':
+    ensure  => 'link',
+    target  => '/usr/bin/chromium-browser',
+    require => Package[$deps],
   }
 
   file { '/etc/conf.d':


### PR DESCRIPTION
On Fedora 32, `chromium` is not installed together with `chromedriver`. I have added the installation and the symlink to make Superset thumbnails work. I tested this and thumbnails get generated.