### PR TITLE
Fix deprecated plus-equal operator

### DIFF
--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -49,7 +49,7 @@ class superset::python inherits superset {
   } else {
     $pip_install_options = [{'-i' => $pip_repo.shift}]
     if $pip_repo.length > 0 {
-      $pip_install_options += [{'--extra-index-url' => $pip_repo.join(' ')}]
+      $pip_install_options = $pip_install_options + {'--extra-index-url' => $pip_repo.join(' ')}
     }
   }
   python::pip { 'apache-superset':


### PR DESCRIPTION
As per https://tickets.puppetlabs.com/browse/PUP-2972 , the `+=` is now
deprecated. This causes an issue in `manifests/python.pp`, line: 52, column: 28.

When concatenating an Array with an additional element, it is not
necessary to pass the latter as an array itself (see
https://puppet.com/docs/puppet/6/lang_expressions.html#lang_exp_array-array-concatenation
).

Signed-off-by: Étienne Boisseau-Sierra <etienne.boisseau-sierra@unipart.io>