### PR TITLE
Fix pip install args

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,4 +20,3 @@ superset::ldap_enabled: false
 superset::ldap_filter_login: true
 superset::row_limit: None
 superset::dynamic_plugins: false
-superset::pip_repo: []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,8 @@ class superset (
   Hash[String, Array[String]] $ldap_roles_mapping,
   Optional[String] $logo_path = undef,
   Optional[String] $ldap_user_filter = undef,
+  Optional[String] $pip_index_url = undef,
+  Optional[Array[String]] $pip_install_args = undef,
 ) {
   contain superset::db
   contain superset::selinux

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -44,22 +44,22 @@ class superset::python inherits superset {
   }
 
   # from https://puppet.com/docs/puppet/7.6/types/package.html#package-attribute-install_options
-  if $pip_repo == [] {
+  if !($pip_repo) or $pip_repo == [] {
     $pip_install_options = []
   } else {
-    $pip_install_options = [{'-i' => $pip_repo.shift}]
-    if $pip_repo.length > 0 {
-      $pip_install_options = $pip_install_options + {'--extra-index-url' => $pip_repo.join(' ')}
+    $pip_install_options = [{'-i' => $pip_repo[0]}]
+    if $pip_repo.length > 1 {
+      $pip_install_options = $pip_install_options + {'--extra-index-url' => $pip_repo[1,-1].join(' ')}
     }
   }
   python::pip { 'apache-superset':
-    ensure          => $version,
-    extras          => ['prophet', 'postgres'],
-    virtualenv      => "${base_dir}/venv",
-    pip_provider    => 'pip3',
-    install_options => $pip_install_options,
-    owner           => $owner,
-    require         => [Python::Pip['pystan'], Python::Pip[$deps]]
+    ensure       => $version,
+    extras       => ['prophet', 'postgres'],
+    virtualenv   => "${base_dir}/venv",
+    pip_provider => 'pip3',
+    install_args => $pip_install_options.join(' '),
+    owner        => $owner,
+    require      => [Python::Pip['pystan'], Python::Pip[$deps]]
   }
 
   exec { "restorecon -r ${base_dir}/venv/bin":

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -43,21 +43,17 @@ class superset::python inherits superset {
     require      => Python::Pip['pystan']
   }
 
-  # from https://puppet.com/docs/puppet/7.6/types/package.html#package-attribute-install_options
-  if !($pip_repo) or $pip_repo == [] {
-    $pip_install_options = []
-  } else {
-    $pip_install_options = [{'-i' => $pip_repo[0]}]
-    if $pip_repo.length > 1 {
-      $pip_install_options = $pip_install_options + {'--extra-index-url' => $pip_repo[1,-1].join(' ')}
-    }
+  if !($pip_install_args) {
+    $pip_install_args = []
   }
+
   python::pip { 'apache-superset':
     ensure       => $version,
     extras       => ['prophet', 'postgres'],
     virtualenv   => "${base_dir}/venv",
     pip_provider => 'pip3',
-    install_args => $pip_install_options.join(' '),
+    index        => $pip_index_url,
+    install_args => $pip_install_args.join(' '),
     owner        => $owner,
     require      => [Python::Pip['pystan'], Python::Pip[$deps]]
   }

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -49,7 +49,7 @@ class superset::python inherits superset {
   } else {
     $pip_install_options = [{'-i' => $pip_repo.shift}]
     if $pip_repo.length > 0 {
-      $pip_install_options += [{'--extra-index-url' => $pip_repo.join(' ')}]
+      $pip_install_options = $pip_install_options + {'--extra-index-url' => $pip_repo.join(' ')}
     }
   }
   python::pip { 'apache-superset':


### PR DESCRIPTION
**Note:** This PR is built on top of #15 . Please merge #15 first.

---

We have fixed a set of issues related to how install arguments passed to
pip to install the `apache-superset` package are defined. These are:

- Handle the case where `$pip_repo` is Undef (should be the same as when
  it's an empty Array),
- Fix the usage of `Array.shift` that doesn't exist in Puppet.
  `$pip_repo` contains first the additional “forge” URL, then some
  install args. So we use the first arguments for `pip -i`, then — iff
  there are other ones (i.e., len > 1) — we parse them as well.
- Use `install_args` instead of the non-existing `install_options` (cf.
  https://forge.puppet.com/modules/puppet/python/reference#pythonpip).
- Ensure that the argument is a String instead of an Array.
