### PR TITLE
Make manifest Debian-friendly

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -13,9 +13,15 @@ class superset::db inherits superset {
     }
 
     if defined('pgdump::dump') {
+      $pg_base_dir = downcase($::osfamily) ? {
+        'RedHat' => '/var/lib/pgsql',
+        'Debian' => '/var/lib/postgresql',
+        default  => undef
+      }
+
       class { 'pgdump::dump':
         db_name     => $db_name,
-        db_dump_dir => '/var/lib/pgsql/dump',
+        db_dump_dir => "${$pg_base_dir}/dump"
         require     => Postgresql::Server::Db[$db_name]
       }
     }

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -14,8 +14,8 @@ class superset::db inherits superset {
 
     if defined('pgdump::dump') {
       $pg_base_dir = downcase($::osfamily) ? {
-        'RedHat' => '/var/lib/pgsql',
-        'Debian' => '/var/lib/postgresql',
+        'redhat' => '/var/lib/pgsql',
+        'debian' => '/var/lib/postgresql',
         default  => undef
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,6 @@ class superset (
   Optional[String] $ldap_user_filter = undef,
 ) {
   contain superset::db
-  contain superset::selinux
   contain superset::package
   contain superset::python
   contain superset::celery
@@ -37,4 +36,7 @@ class superset (
   contain superset::config
   contain superset::install
   contain superset::service
+  if downcase($::osfamily) == 'RedHat'{
+    contain superset::selinux
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@ class superset (
   contain superset::config
   contain superset::install
   contain superset::service
-  if downcase($::osfamily) == 'RedHat'{
+  if downcase($::osfamily) == 'redhat'{
     contain superset::selinux
   }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -3,7 +3,7 @@ class superset::package inherits superset {
 
   $generic_deps = ['git']
 
-  if downcase($::osfamily) == 'RedHat'{
+  if downcase($::osfamily) == 'redhat'{
     $deps = $generic_deps + [
       'chromedriver',
       'chromium',
@@ -14,7 +14,7 @@ class superset::package inherits superset {
       'openldap-devel',
       'openssl-devel',
     ]
-  } elsif downcase($::osfamily) == 'Debian'{
+  } elsif downcase($::osfamily) == 'debian'{
     $deps = $generic_deps + [
       'chromium-browser',
       'ldap-utils',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,9 +1,31 @@
 # =Class superset::package
 class superset::package inherits superset {
-  $deps = [
-    'gcc', 'gcc-c++', 'libffi-devel', 'chromium', 'chromedriver', 'git',
-    'openssl-devel', 'cyrus-sasl-devel', 'openldap-devel'
-  ]
+
+  $generic_deps = ['git']
+
+  if downcase($::osfamily) == 'RedHat'{
+    $deps = $generic_deps + [
+      'chromedriver',
+      'chromium',
+      'cyrus-sasl-devel',
+      'gcc-c++',
+      'gcc',
+      'libffi-devel',
+      'openldap-devel',
+      'openssl-devel',
+    ]
+  } elsif downcase($::osfamily) == 'Debian'{
+    $deps = $generic_deps + [
+      'chromium-browser',
+      'ldap-utils',
+      'libsasl2-dev',
+      'libssl-dev',
+      'policycoreutils',
+      'python3-ldap',
+      'libldap2-dev',
+      'python3-pyldap',
+    ]
+  }
 
   package { $deps:
     ensure => present

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -1,7 +1,9 @@
 # =Class superset::python
 class superset::python inherits superset {
-  require superset::selinux
   require superset::package
+  if downcase($::osfamily) == 'RedHat'{
+    require superset::selinux
+  }
 
   class { 'python':
     pip => present,
@@ -24,7 +26,13 @@ class superset::python inherits superset {
   }
 
   $deps = [
-    'eventlet', 'gevent', 'greenlet', 'gsheetsdb', 'gunicorn', 'pyldap', 'sqlalchemy'
+    'eventlet',
+    'gevent',
+    'greenlet',
+    'gsheetsdb',
+    'gunicorn',
+    'pyldap',
+    'sqlalchemy',
   ]
 
   python::pip { 'pystan':

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -1,7 +1,7 @@
 # =Class superset::python
 class superset::python inherits superset {
   require superset::package
-  if downcase($::osfamily) == 'RedHat'{
+  if downcase($::osfamily) == 'redhat'{
     require superset::selinux
   }
 

--- a/templates/etc/systemd/system/celery.service.erb
+++ b/templates/etc/systemd/system/celery.service.erb
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=forking
-User=fedora
-Group=fedora
+User=<%= @owner %>
+Group=<%= @group %>
 EnvironmentFile=/etc/conf.d/celery
 WorkingDirectory=<%= @base_dir %>
 ExecStart=/bin/sh -c '${CELERY_BIN} -A $CELERY_APP multi start $CELERYD_NODES \

--- a/templates/etc/systemd/system/gunicorn.service.erb
+++ b/templates/etc/systemd/system/gunicorn.service.erb
@@ -5,8 +5,8 @@ After=network.target
 
 [Service]
 Type=notify
-User=fedora
-Group=fedora
+User=<%= @owner %>
+Group=<%= @group %>
 RuntimeDirectory=gunicorn
 WorkingDirectory=<%= @base_dir %>
 EnvironmentFile=/etc/conf.d/gunicorn


### PR DESCRIPTION
We want to have an Agent running on a Debian-based OS be able to run the
manifest. For that a few changes were necessary:

- Ensure any SELinux-specific confic is contained in a RHEL-based OS
  only case statement. Indeed, SELinux doesn't exist in Debian-based OS,
  so we have ensured that any SELinux-linked code is run for RH-based OS
  only.
- De-hard-code the user/group in service templates, so that they are run
  by whomever the superset::user is.
- Make the dependencies OS-specific and find the right mix for Debian /
  Ubuntu.
- One package per line in Arrays, to keep future diffs cleaner.

Signed-off-by: Étienne Boisseau-Sierra <etienne.boisseau-sierra@unipart.io>