### PR TITLE
Python version as param

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,7 +6,7 @@ superset::group: fedora
 superset::db_host: localhost
 superset::db_name: superset
 superset::db_user: superset
-superset::version: present
+superset::superset_version: present
 superset::ldap_server: ''
 superset::ldap_bind_user: ''
 superset::ldap_bind_pass: ''

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class superset (
   Variant[Enum['system', 'pypy'], String[1]] $python_version,
   Integer $concurrency,
   Variant[Integer, Enum['None']] $row_limit,
-  Variant[Enum[present, absent, latest], String[1]] $version,
+  Variant[Enum[present, absent, latest], String[1]] $superset_version,
   Optional[String[1]] $package_index_url = undef,
   Optional[String[1]] $package_index_username = undef,
   Optional[String[1]] $package_index_password = undef,

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -55,7 +55,7 @@ class superset::python inherits superset {
   }
 
   python::pip { 'apache-superset':
-    ensure       => $version,
+    ensure       => $superset_version,
     extras       => ['prophet', 'postgres'],
     virtualenv   => "${base_dir}/venv",
     pip_provider => 'pip3',


### PR DESCRIPTION
We introduce the `$python_version` parameter instead of an hardcoded value.