### PR TITLE
Replace curl with wget

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -63,7 +63,7 @@ class superset::package inherits superset {
   exec { 'install chromedriver':
     command => join([
       "wget",
-      "https://chromedriver.storage.googleapis.com/$(curl",
+      "https://chromedriver.storage.googleapis.com/$(wget --no-check-certificate -qO -",
       "\"https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | gawk 'match(\$0, /\s([0-9]*)\./, g) {print g[1]}')\")/chromedriver_linux64.zip",
       "&& unzip chromedriver_linux64.zip",
       "&& rm chromedriver_linux64.zip",


### PR DESCRIPTION
Dropping `curl` for `wget` as the latter comes installed, and the former does not.

I tested, but could not confirm because of the issues with `wtforms` in https://github.com/dpgaspar/Flask-AppBuilder/issues/1732. The installation did pass the chrome/chromedriver bits correctly though.