### PR TITLE
Specify extra dependencies to `apache-superset` package via hiera param

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -21,4 +21,3 @@ superset::manage_database: true
 superset::ldap_enabled: false
 superset::ldap_filter_login: true
 superset::row_limit: None
-superset::dynamic_plugins: false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -21,3 +21,4 @@ superset::manage_database: true
 superset::ldap_enabled: false
 superset::ldap_filter_login: true
 superset::row_limit: None
+superset::superset_extras: ['postgres']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class superset (
   Integer $concurrency,
   Variant[Integer, Enum['None']] $row_limit,
   Variant[Enum[present, absent, latest], String[1]] $superset_version,
+  Array[String[1]] $superset_extras,
   Optional[String[1]] $package_index_url = undef,
   Optional[String[1]] $package_index_username = undef,
   Optional[String[1]] $package_index_password = undef,

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -57,7 +57,7 @@ class superset::python inherits superset {
 
   python::pip { 'apache-superset':
     ensure       => $superset_version,
-    extras       => ['prophet', 'postgres'],
+    extras       => $superset_extras,
     virtualenv   => "${base_dir}/venv",
     pip_provider => 'pip3',
     index        => $package_index,


### PR DESCRIPTION
We have kept `'postgres'` as a default, but omit `prophet`.