### PR TITLE
Enable MySQL dbs

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,9 +12,9 @@ class superset::package inherits superset {
 
     exec { 'enable chrome':
       command => 'dnf config-manager --set-enabled google-chrome',
-      user        => 'root',
-      group       => 'root',
-      path        => '/usr/sbin:/usr/bin:/sbin:/bin',
+      user    => 'root',
+      group   => 'root',
+      path    => '/usr/sbin:/usr/bin:/sbin:/bin',
       require => Package[$pre_deps],
     }
 
@@ -34,7 +34,7 @@ class superset::package inherits superset {
       ensure  => present,
       require => Exec['enable chrome'],
     }
-    
+
   } elsif downcase($::osfamily) == 'debian'{
     $deps = [
       'gawk',
@@ -62,16 +62,16 @@ class superset::package inherits superset {
 
   exec { 'install chromedriver':
     command => join([
-      "wget",
-      "https://chromedriver.storage.googleapis.com/$(wget --no-check-certificate -qO -",
+      'wget',
+      'https://chromedriver.storage.googleapis.com/$(wget --no-check-certificate -qO -',
       "\"https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | gawk 'match(\$0, /\s([0-9]*)\./, g) {print g[1]}')\")/chromedriver_linux64.zip",
-      "&& unzip chromedriver_linux64.zip",
-      "&& rm chromedriver_linux64.zip",
-      "&& mv chromedriver /usr/local/bin",
+      '&& unzip chromedriver_linux64.zip',
+      '&& rm chromedriver_linux64.zip',
+      '&& mv chromedriver /usr/local/bin',
     ], ' '),
-    user        => 'root',
-    group       => 'root',
-    path        => '/usr/sbin:/usr/bin:/sbin:/bin',
+    user    => 'root',
+    group   => 'root',
+    path    => '/usr/sbin:/usr/bin:/sbin:/bin',
     require => File['/usr/bin/google-chrome']
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -57,22 +57,27 @@ class superset::package inherits superset {
 
     if 'mysql' in $superset_extras {
       # `mysqlclient` dependencies, cf. https://pypi.org/project/mysqlclient/
-      # 'python3-dev' is omitted as already installed
+      # Omitting 'python3-dev' that clashed with later Python install
       $mysql_deps = ['default-libmysqlclient-dev', 'build-essential']
     } else {
       $mysql_deps = []
     }
 
-    package { $base_deps + $mysql_deps:
-      ensure  => present,
-      require => Apt::Source['google-chrome'],
-    }
+    $os_dependencies = $base_deps + $mysql_deps
+
+    ensure_resources(
+      'package',
+      $os_dependencies => {
+        ensure  => present,
+        require => Apt::Source['google-chrome'],
+      }
+    )
   }
 
   file { '/usr/bin/google-chrome':
     ensure  => 'link',
     target  => '/usr/bin/google-chrome-stable',
-    require => Package['os_dependencies'],
+    require => Package[$os_dependencies],
   }
 
   exec { 'install chromedriver':


### PR DESCRIPTION

    To be able to connect to MySQL dbs, one need to install the `mysql`
    extras of the `apache-superset` Python package.
    
    This extra dependency contains the `mysqlclient` package, which has OS
    dependencies listed here: https://pypi.org/project/mysqlclient/
    
    We make sure that these OS dependencies are installed (only if we
    require MySQL).