### PR TITLE
Implement custom time grain definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,15 +32,15 @@ class superset (
   Boolean $smtp_ssl,
   Boolean $manage_database,
   Boolean $ldap_filter_login,
-  Hash[String, Array[String]] $ldap_roles_mapping,
+  Hash[String[1], Array[String[1]]] $ldap_roles_mapping,
   Boolean $enable_js_controls,
   Optional[String[1]] $package_index_url = undef,
   Optional[String[1]] $package_index_username = undef,
   Optional[String[1]] $package_index_password = undef,
-  Optional[Hash[String, Boolean]] $feature_flags = undef,
+  Optional[Hash[String[1], Boolean]] $feature_flags = undef,
   Optional[String] $logo_path = undef,
   Optional[String] $ldap_user_filter = undef,
-  Optional[Hash[String, String]] $jinja_context_addons = undef,
+  Optional[Hash[String[1], String[1]]] $jinja_context_addons = undef,
 ) {
   contain superset::db
   contain superset::package

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class superset (
   Optional[String] $logo_path = undef,
   Optional[String] $ldap_user_filter = undef,
   Optional[Hash[String[1], String[1]]] $jinja_context_addons = undef,
+  Optional[Hash[String[1], Array[Hash[String[1], String[1]]]]] $time_grain_addons = undef,
 ) {
   contain superset::db
   contain superset::package

--- a/templates/opt/superset/superset_config.py.erb
+++ b/templates/opt/superset/superset_config.py.erb
@@ -175,3 +175,26 @@ JINJA_CONTEXT_ADDONS = {
 <% end -%>
 }
 <% end -%>
+
+
+<% if @time_grain_addons -%>
+# Define how to compute the custom time buckets
+TIME_GRAIN_ADDON_EXPRESSIONS = {
+<% @time_grain_addons.each do | db_engine, addons | -%>
+    "<%= db_engine %>": {
+<% addons.each do |addon| -%>
+        "<%= addon['id'] %>": "<%= addon['definition'] %>",
+<% end -%>
+    }
+<% end -%>
+}
+
+# Register these custom time grain
+TIME_GRAIN_ADDONS = {
+<% @time_grain_addons.each do | db_engine, addons | -%>
+<% addons.each do |addon| -%>
+    "<%= addon['id'] %>": "<%= addon['name'] %>",
+<% end -%>
+<% end -%>
+}
+<% end -%>


### PR DESCRIPTION
Passing the following hiera param

```yaml
superset::time_grain_addons: {
  postgresql: [
    {
      id: "PT15M",
      name: "15 minutes",
      definition: "date_trunc('hour', {col}) + date_part('minute', {col})::int / 15 * interval '15 min'",
    },
    {
      id: "PT6H",
      name: "6 hours",
      definition: "date_trunc('day', {col}) + date_trunc('hour', {col})::int / 6 * interval '6 h'",
    },
  ]
}
```

would result in the following addition in `config.py`:

```python
TIME_GRAIN_ADDON_EXPRESSIONS = {
    'postgresql': {
        'PT6H': "date_trunc('day', {col}) + date_trunc('hour', {col})::int / 6 * interval '6 h'",
        'PT15M': "date_trunc('hour', {col}) + date_part('minute', {col})::int / 15 * interval '15 min'",
    },
}

TIME_GRAIN_ADDONS = {
    "PT6H": "6 hours",
    "PT15M": "15 minutes",
}
```