### PR TITLE
feat(timegrain): Implement time grain blacklist

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@ class superset (
   Optional[String] $ldap_user_filter = undef,
   Optional[Hash[String[1], String[1]]] $jinja_context_addons = undef,
   Optional[Hash[String[1], Array[Hash[String[1], String[1]]]]] $time_grain_addons = undef,
+  Optional[Array[String[1]]] $time_grain_denylist = undef,
 ) {
   contain superset::db
   contain superset::package

--- a/templates/opt/superset/superset_config.py.erb
+++ b/templates/opt/superset/superset_config.py.erb
@@ -198,3 +198,11 @@ TIME_GRAIN_ADDONS = {
 <% end -%>
 }
 <% end -%>
+
+<% if @time_grain_denylist -%>
+TIME_GRAIN_DENYLIST = [
+<% @time_grain_denylist.each do |time_grain| -%>
+    "<%= time_grain %>",
+<% end -%>
+]
+<% end -%>


### PR DESCRIPTION
Enable the definition of a [time grain denylist](https://github.com/apache/superset/blob/0de03c4b34fd13d4f751710277ede3ca0c9b1033/superset/config.py#L619-L623) via hiera params.

Signed-off-by: Étienne Boisseau-Sierra <etienne.boisseau-sierra@unipart.io>