### PR TITLE
feat. Debian 11 support

### DIFF
--- a/data/os/Debian/10.yaml
+++ b/data/os/Debian/10.yaml
@@ -1,0 +1,10 @@
+---
+superset::pip_deps:
+ - eventlet
+ - gevent
+ - greenlet
+ - gsheetsdb
+ - gunicorn
+ - pyldap
+ - sqlalchemy
+ - systemd

--- a/data/os/Debian/11.yaml
+++ b/data/os/Debian/11.yaml
@@ -1,0 +1,13 @@
+---
+superset::pip_deps:
+ - setuptools
+ - wheel
+ - eventlet
+ - gevent
+ - greenlet
+ - gsheetsdb
+ - gunicorn
+ - python-ldap
+ - sqlalchemy
+ - cysystemd
+ - 'markupsafe==2.0.1'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,6 +5,11 @@ defaults:
   data_hash: yaml_data
 hierarchy:
 
+  - name: "Operating system"
+    paths:
+      - "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+      - "os/%{facts.os.family}.yaml"
+
   - name: "common"
     path: "common.yaml"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class superset (
   String $smtp_mail_from,
   String $log_level,
   String $pip_args,
+  Array $pip_deps,
   Variant[Enum['system', 'pypy'], String[1]] $python_version,
   Integer $concurrency,
   Integer $smtp_port,

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -26,18 +26,7 @@ class superset::python inherits superset {
     require  => [Class['python'], File[$base_dir]],
   }
 
-  $deps = [
-    'eventlet',
-    'gevent',
-    'greenlet',
-    'gsheetsdb',
-    'gunicorn',
-    'pyldap',
-    'sqlalchemy',
-    'systemd',
-  ]
-
-  python::pip { $deps:
+  python::pip { $pip_deps:
     ensure       => present,
     virtualenv   => "${base_dir}/venv",
     pip_provider => 'pip3',
@@ -63,7 +52,7 @@ class superset::python inherits superset {
     index        => $package_index,
     install_args => $pip_args,
     owner        => $owner,
-    require      => [Python::Pip[$deps]]
+    require      => [Python::Pip[$pip_deps]]
   }
 
   exec { "restorecon -r ${base_dir}/venv/bin":

--- a/templates/opt/superset/superset_config.py.erb
+++ b/templates/opt/superset/superset_config.py.erb
@@ -5,7 +5,11 @@ from logging.handlers import TimedRotatingFileHandler
 from celery.schedules import crontab
 from celery.signals import after_setup_logger, after_setup_task_logger
 from flask_appbuilder.security.manager import AUTH_DB, AUTH_LDAP
+<%- if @os['name'] == 'Debian' and @os['release']['major'] <= '11' -%>
+from cysystemd.journal import JournaldLogHandler
+<%- else -%>
 from systemd.journal import JournaldLogHandler
+<% end -%>
 from superset.utils.logging_configurator import DefaultLoggingConfigurator
 
 


### PR DESCRIPTION
- Pip dependencies moved to Hiera, based on OS major version requirements
- Python `cysystemd ` instead of `systemd` in `superset_config.py` for Deb 11, due to compatibility